### PR TITLE
Code Page Encodings for .NET Core

### DIFF
--- a/src/HtmlAgilityPack.NetCore/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.NetCore/HtmlDocument.cs
@@ -1655,7 +1655,11 @@ namespace HtmlAgilityPack
 						charset = "utf-8";
 					try
 					{
+#if CodePages
+						_declaredencoding = CodePagesEncodingProvider.Instance.GetEncoding(charset);
+#else
 						_declaredencoding = Encoding.GetEncoding(charset);
+#endif
 					}
 					catch (ArgumentException)
 					{

--- a/src/HtmlAgilityPack.NetCore/project.json
+++ b/src/HtmlAgilityPack.NetCore/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "HtmlAgilityPack for .NET Core",
-  "version": "1.5.0.1",
+  "version": "1.5.0.2",
   "summary": "This is an agile HTML parser that builds a read/write DOM and supports plain XPATH or XSLT (you actually don't HAVE to understand XPATH nor XSLT to use it, don't worry...). It is a .NET code library that allows you to parse \"out of the web\" HTML files. The parser is very tolerant with \"real world\" malformed HTML. The object model is very similar to what proposes System.Xml, but for HTML documents (or streams).",
   "description": "This is a port of HtmlAgilityPack library created by Simon Mourrier and Jeff Klawiter for .NET Core platform. This NuGet package supports can be used with Universal Windows Platform, ASP.NET 5 (using .NET Core) and full .NET Framework 4.6.\r\n\r\nOriginal description:\r\n\r\nThis is an agile HTML parser that builds a read/write DOM and supports plain XPATH or XSLT (you actually don't HAVE to understand XPATH nor XSLT to use it, don't worry...). It is a .NET code library that allows you to parse \"out of the web\" HTML files. The parser is very tolerant with \"real world\" malformed HTML. The object model is very similar to what proposes System.Xml, but for HTML documents (or streams).",
   "authors": [ "Zulfahmi Ahmad" ],
@@ -16,7 +16,11 @@
       }
     },
     "netstandard1.3": {
+      "buildOptions": {
+        "define": [ "CodePages" ]
+      },
       "dependencies": {
+        "System.Text.Encoding.CodePages": "4.0.1",
         "System.Collections": "4.0.11",
         "System.Linq": "4.1.0",
         "System.Threading": "4.0.11",


### PR DESCRIPTION
.NET Core only comes with a limited number of encodings. This change add support for most code pages supported by .NET Framework by adding a dependency of `System.Text.Encoding.CodePages`.